### PR TITLE
fix(react): remove optional children prop

### DIFF
--- a/packages/react/src/defineRequirement.tsx
+++ b/packages/react/src/defineRequirement.tsx
@@ -1,7 +1,5 @@
 import React, { ReactNode } from 'react';
 
-type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-
-export const defineRequirement = <T extends {children?: ReactNode}>(Requirement: React.ComponentType<T>, props?: Omit<T, 'children'>) =>
+export const defineRequirement = <T extends {}>(Requirement: React.ComponentType<T>, props?: Pick<T, Exclude<keyof T, 'children'>>) =>
     (app: ReactNode) =>
         <Requirement { ...props }>{ app }</Requirement>;


### PR DESCRIPTION
## Description of Change
Some components do not define children in their propTypes. We should not force them, because this is optional prop anyway.
